### PR TITLE
Bug fix/ssh already exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,12 +17,13 @@ echo
 echo
 
 if ls ~/.ssh/*.pub 2>/dev/null; then
-	echo "public key found in ~/.ssh/id_ed25519.pub"
+	KEY_FILE=$(ls ~/.ssh/*.pub | head -1)
+	echo "public key found in ${KEY_FILE}"
   echo
 	echo "Make sure to copy the following and add the key to your GitHub account."
 	echo "See https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account"
 	echo
-	cat ~/.ssh/id_ed25519.pub
+	cat ${KEY_FILE}
 	echo
 	read -p "Press any key to continue"
 else

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ echo "
 echo
 echo "===================================="
 echo "Installation Script v1.0.0    "
-echo "For support contact samuelch@ethz.ch"
+echo "For support contact fheemeyer@ethz.ch"
 echo "===================================="
 echo 
 echo


### PR DESCRIPTION
Fixed the bug that the script tried to use the key ~/.ssh/id_ed25519.pub although it was possible that it did not exist. It now takes the first key it finds in .shh/ instead of using the hard-coded ~/.ssh/id_ed25519.pub whcih might not exist. If there is no key at all in .shh/, the script remains unchanged. 